### PR TITLE
FPM-566 Add ARG_ID_EXTRACT_REGEX for metadata argument parsing

### DIFF
--- a/src/driutils/metadata_api/utils.py
+++ b/src/driutils/metadata_api/utils.py
@@ -9,6 +9,10 @@ URI_ID_EXTRACT_REGEX = r".+\/([a-zA-Z0-9\-\_]+)$"
 #   e.g. http://fdri.ceh.ac.uk/id/site/cosmos-chimn => chimn
 SITE_ID_EXTRACT_REGEX = r".+\/\w+\-([a-zA-Z0-9]+)$"
 
+# To get the url fragment from the uri string. Used for arguments.
+#   e.g http://fdri.ceh.ac.uk/id/configuration-item/cosmos-config-item-1#correction-factor => correction-factor
+ARG_ID_EXTRACT_REGEX = r".+#(.+)$"
+
 
 def check_single_list_item(data: List) -> Any:
     """Checks that list has a single item within in.


### PR DESCRIPTION
Small change to add this to be used in the processor for parsing arguments from the metadata service.