### PR TITLE
Add batch transformer and model

### DIFF
--- a/src/driutils/metadata_api/api_manager.py
+++ b/src/driutils/metadata_api/api_manager.py
@@ -243,7 +243,7 @@ class MetadataAPIManager:
         async with AsyncClient() as client:
             try:
                 response = await client.get(
-                    f"{self.base_url}/id/dataset.json",
+                    f"{self.host}/id/dataset.json",
                     params=params,
                 )
                 return response.json()

--- a/src/driutils/metadata_api/api_manager.py
+++ b/src/driutils/metadata_api/api_manager.py
@@ -220,3 +220,34 @@ class MetadataAPIManager:
         response = await self._make_paginated_api_call(url, base_parameters | timeseries_def_parameter)
 
         return response
+
+    async def fetch_batches(self, batch_id: str | None) -> Dict[str, Any]:
+        """
+        Fetch batch metadata. If no batch_id is provided then fetches all batches.
+
+        Returns:
+            The JSON response from the API
+
+        Raises:
+            HTTPException: If the API request fails or returns an error
+
+        """
+        dataset_type = "http://fdri.ceh.ac.uk/vocab/metadata/ObservationDatasetSeries"
+        originating_programme = "http://fdri.ceh.ac.uk/id/programme/nrfa"
+        view = "datasetseries"
+        params = {"@type": dataset_type, "originatingProgramme": originating_programme, "_view": view}
+
+        if batch_id:
+            params["@id"] = f"http://fdri.ceh.ac.uk/id/dataset/nrfa-batch-{batch_id}"
+
+        async with AsyncClient() as client:
+            try:
+                response = await client.get(
+                    f"{self.base_url}/id/dataset.json",
+                    params=params,
+                )
+                return response.json()
+            except HTTPError as e:
+                logger.error(f"Failed to fetch list of available networks: {str(e)}")
+                logger.exception(e)
+                raise e

--- a/src/driutils/metadata_api/models/batch.py
+++ b/src/driutils/metadata_api/models/batch.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TypedDict
+
+
+@dataclass
+class BatchDataset:
+    """Batch dataset model
+
+    Attributes:
+        batch_dataset_id: The ID of the dataset
+        filename: Which uploaded filename the data comes from
+        site: The NRFA site ID
+        status: The processing status of the dataset
+        resolution: The resolution
+        measure: The dataset measure
+            composed of variable-resolution-aggregation-units if its an aggregate measure
+            composed of variable-resolution-units if instantaneous measure
+        dataset: the type of dataset e.g. water-daily-flow-mean
+        start_date: the series start date
+        end_date: the series end date
+        s3_key: the s3 key for the data
+        s3_bucket: the s3 bucket where the data is stored
+        s3_column: the column contaiing the values
+    """
+
+    batch_dataset_id: str
+    filename: str
+    site: str
+    variable: str
+    aggregation: str
+    units: str
+    status: str
+    resolution: str
+    measure: str
+    dataset: str
+    start_date: datetime | None
+    end_date: datetime | None
+    s3_key: str
+    s3_bucket: str
+    s3_column: str
+
+
+@dataclass
+class Batch(TypedDict):
+    """Batch Model
+
+    Attributes:
+        batch_id: The batch id
+        datasets: The datasets that comprise the batch
+    """
+
+    batch_id: str
+    datasets: list[BatchDataset]

--- a/src/driutils/metadata_api/transformers/batches.py
+++ b/src/driutils/metadata_api/transformers/batches.py
@@ -1,0 +1,102 @@
+import re
+from datetime import datetime
+from typing import Any
+
+from driutils.metadata_api.models.batch import Batch, BatchDataset
+
+URI_ID_EXTRACT_REGEX = r".+\/([a-zA-Z0-9\-\_]+)$"
+
+
+class BatchTransformer:
+    """Class for transforming metadata API batches responses into required format."""
+
+    @staticmethod
+    def _get_property(key: str, prop: dict[str, Any] | None) -> Any:
+        """
+        Given a dict like {key: [a,b,c]}, the first value of the list will be returned
+        Given a dict like {key: a}, a will be returned
+        """
+        if not prop:
+            return None
+        values = prop.get(key)
+        if isinstance(values, list):
+            return values[0]
+        return values
+
+    def transform(self, raw_data: dict) -> list[Batch]:
+        """Transform the raw API response into the desired format.
+
+        Args:
+            raw_data: Raw data from the API
+
+        Returns:
+            Transformed data with list of Batch objects
+        """
+        batches = []
+
+        for item in raw_data["items"]:
+            batch_id = BatchTransformer._get_property("identifier", item)
+            datasets = []
+            annotations = {}
+            for data in item["hasPart"]:
+                batch_dataset_id = BatchTransformer._get_property("@id", data)
+
+                site = BatchTransformer._get_property("@id", BatchTransformer._get_property("originatingSite", data))
+                if site:
+                    site = site.split("/")[-1].split("-")[-1]
+
+                processing_level = BatchTransformer._get_property(
+                    "@id", BatchTransformer._get_property("processingLevel", data)
+                )
+                if processing_level:
+                    processing_level = processing_level.split("/")[-1]
+
+                measure = BatchTransformer._get_property("@id", BatchTransformer._get_property("measure", data))
+                variable, resolution, aggregation, units = [""] * 4
+                if measure:
+                    variable, resolution, aggregation, units = measure.split("-")
+                    # Remove the id (e.g. http://fdri.ceh.ac.uk) from the variable section
+                    match = re.match(URI_ID_EXTRACT_REGEX, variable)
+                    variable = match.group(1) if match else variable
+                    # Reconstruct the measure now that the id prefix has been removed.
+                    measure = f"{variable}-{resolution}-{aggregation}-{units}"
+
+                for annotation in data["hasAnnotation"]:
+                    annotation_name = re.search(r"#(.*)$", BatchTransformer._get_property("@id", annotation))
+                    if annotation_name:
+                        annotations[annotation_name.group(1)] = BatchTransformer._get_property(
+                            "value", BatchTransformer._get_property("hasValue", annotation)
+                        )
+
+                s3_key = data["sourceDataset"]
+                s3_column = data["sourceColumnName"]
+                s3_bucket = data["sourceBucket"]
+
+                start_date = None
+                end_date = None
+                if data.get("temporal"):
+                    start_date = datetime.strptime(data["temporal"]["startDate"], "%Y-%m-%dT%H:%M:%S")
+                    end_date = datetime.strptime(data["temporal"]["endDate"], "%Y-%m-%dT%H:%M:%S")
+
+                dataset = BatchDataset(
+                    batch_dataset_id=batch_dataset_id,
+                    variable=variable,
+                    units=units,
+                    aggregation=aggregation,
+                    filename=annotations["filename"],
+                    resolution=resolution,
+                    site=site,
+                    status=processing_level,
+                    measure=measure,
+                    dataset=annotations["dataset"],
+                    start_date=start_date,
+                    end_date=end_date,
+                    s3_key=s3_key,
+                    s3_column=s3_column,
+                    s3_bucket=s3_bucket,
+                )
+                datasets.append(dataset)
+
+            batches.append(Batch(batch_id=batch_id, datasets=datasets))
+
+        return batches

--- a/src/driutils/metadata_api/transformers/batches.py
+++ b/src/driutils/metadata_api/transformers/batches.py
@@ -1,102 +1,82 @@
 import re
 from datetime import datetime
-from typing import Any
 
 from driutils.metadata_api.models.batch import Batch, BatchDataset
+from driutils.metadata_api.utils import get_property
 
 URI_ID_EXTRACT_REGEX = r".+\/([a-zA-Z0-9\-\_]+)$"
 
 
-class BatchTransformer:
-    """Class for transforming metadata API batches responses into required format."""
+def transform_batches(raw_data: dict) -> list[Batch]:
+    """Transform the raw API response into the desired format.
 
-    @staticmethod
-    def _get_property(key: str, prop: dict[str, Any] | None) -> Any:
-        """
-        Given a dict like {key: [a,b,c]}, the first value of the list will be returned
-        Given a dict like {key: a}, a will be returned
-        """
-        if not prop:
-            return None
-        values = prop.get(key)
-        if isinstance(values, list):
-            return values[0]
-        return values
+    Args:
+        raw_data: Raw data from the API
 
-    def transform(self, raw_data: dict) -> list[Batch]:
-        """Transform the raw API response into the desired format.
+    Returns:
+        Transformed data with list of Batch objects
+    """
+    batches = []
 
-        Args:
-            raw_data: Raw data from the API
+    for item in raw_data["items"]:
+        batch_id = get_property("identifier", item)
+        datasets = []
+        annotations = {}
+        for data in item["hasPart"]:
+            batch_dataset_id = get_property("@id", data)
 
-        Returns:
-            Transformed data with list of Batch objects
-        """
-        batches = []
+            site = get_property("@id", get_property("originatingSite", data))
+            if site:
+                site = site.split("/")[-1].split("-")[-1]
 
-        for item in raw_data["items"]:
-            batch_id = BatchTransformer._get_property("identifier", item)
-            datasets = []
-            annotations = {}
-            for data in item["hasPart"]:
-                batch_dataset_id = BatchTransformer._get_property("@id", data)
+            processing_level = get_property("@id", get_property("processingLevel", data))
+            if processing_level:
+                processing_level = processing_level.split("/")[-1]
 
-                site = BatchTransformer._get_property("@id", BatchTransformer._get_property("originatingSite", data))
-                if site:
-                    site = site.split("/")[-1].split("-")[-1]
+            measure = get_property("@id", get_property("measure", data))
+            variable, resolution, aggregation, units = [""] * 4
+            if measure:
+                variable, resolution, aggregation, units = measure.split("-")
+                # Remove the id (e.g. http://fdri.ceh.ac.uk) from the variable section
+                match = re.match(URI_ID_EXTRACT_REGEX, variable)
+                variable = match.group(1) if match else variable
+                # Reconstruct the measure now that the id prefix has been removed.
+                measure = f"{variable}-{resolution}-{aggregation}-{units}"
 
-                processing_level = BatchTransformer._get_property(
-                    "@id", BatchTransformer._get_property("processingLevel", data)
-                )
-                if processing_level:
-                    processing_level = processing_level.split("/")[-1]
+            for annotation in data["hasAnnotation"]:
+                annotation_name = re.search(r"#(.*)$", get_property("@id", annotation))
+                if annotation_name:
+                    annotations[annotation_name.group(1)] = get_property("value", get_property("hasValue", annotation))
 
-                measure = BatchTransformer._get_property("@id", BatchTransformer._get_property("measure", data))
-                variable, resolution, aggregation, units = [""] * 4
-                if measure:
-                    variable, resolution, aggregation, units = measure.split("-")
-                    # Remove the id (e.g. http://fdri.ceh.ac.uk) from the variable section
-                    match = re.match(URI_ID_EXTRACT_REGEX, variable)
-                    variable = match.group(1) if match else variable
-                    # Reconstruct the measure now that the id prefix has been removed.
-                    measure = f"{variable}-{resolution}-{aggregation}-{units}"
+            s3_key = data["sourceDataset"]
+            s3_column = data["sourceColumnName"]
+            s3_bucket = data["sourceBucket"]
 
-                for annotation in data["hasAnnotation"]:
-                    annotation_name = re.search(r"#(.*)$", BatchTransformer._get_property("@id", annotation))
-                    if annotation_name:
-                        annotations[annotation_name.group(1)] = BatchTransformer._get_property(
-                            "value", BatchTransformer._get_property("hasValue", annotation)
-                        )
+            start_date = None
+            end_date = None
+            if data.get("temporal"):
+                start_date = datetime.strptime(data["temporal"]["startDate"], "%Y-%m-%dT%H:%M:%S")
+                end_date = datetime.strptime(data["temporal"]["endDate"], "%Y-%m-%dT%H:%M:%S")
 
-                s3_key = data["sourceDataset"]
-                s3_column = data["sourceColumnName"]
-                s3_bucket = data["sourceBucket"]
+            dataset = BatchDataset(
+                batch_dataset_id=batch_dataset_id,
+                variable=variable,
+                units=units,
+                aggregation=aggregation,
+                filename=annotations["filename"],
+                resolution=resolution,
+                site=site,
+                status=processing_level,
+                measure=measure,
+                dataset=annotations["dataset"],
+                start_date=start_date,
+                end_date=end_date,
+                s3_key=s3_key,
+                s3_column=s3_column,
+                s3_bucket=s3_bucket,
+            )
+            datasets.append(dataset)
 
-                start_date = None
-                end_date = None
-                if data.get("temporal"):
-                    start_date = datetime.strptime(data["temporal"]["startDate"], "%Y-%m-%dT%H:%M:%S")
-                    end_date = datetime.strptime(data["temporal"]["endDate"], "%Y-%m-%dT%H:%M:%S")
+        batches.append(Batch(batch_id=batch_id, datasets=datasets))
 
-                dataset = BatchDataset(
-                    batch_dataset_id=batch_dataset_id,
-                    variable=variable,
-                    units=units,
-                    aggregation=aggregation,
-                    filename=annotations["filename"],
-                    resolution=resolution,
-                    site=site,
-                    status=processing_level,
-                    measure=measure,
-                    dataset=annotations["dataset"],
-                    start_date=start_date,
-                    end_date=end_date,
-                    s3_key=s3_key,
-                    s3_column=s3_column,
-                    s3_bucket=s3_bucket,
-                )
-                datasets.append(dataset)
-
-            batches.append(Batch(batch_id=batch_id, datasets=datasets))
-
-        return batches
+    return batches

--- a/tests/metadata_api/transformers/test_batch_transform.py
+++ b/tests/metadata_api/transformers/test_batch_transform.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from driutils.metadata_api.models.batch import BatchDataset
-from driutils.metadata_api.transformers.batches import BatchTransformer
+from driutils.metadata_api.transformers.batches import transform_batches
 
 
 class TestBatchTransformer:
@@ -9,7 +9,6 @@ class TestBatchTransformer:
 
     def test_transform_batch(self) -> None:
         """Test transforming batches"""
-        transformer = BatchTransformer()
 
         raw_data = {
             "items": [
@@ -149,5 +148,5 @@ class TestBatchTransformer:
             }
         ]
 
-        result = transformer.transform(raw_data)
+        result = transform_batches(raw_data)
         assert result == expected_response

--- a/tests/metadata_api/transformers/test_batch_transform.py
+++ b/tests/metadata_api/transformers/test_batch_transform.py
@@ -1,0 +1,153 @@
+from datetime import datetime
+
+from driutils.metadata_api.models.batch import BatchDataset
+from driutils.metadata_api.transformers.batches import BatchTransformer
+
+
+class TestBatchTransformer:
+    """Test the batch transformer"""
+
+    def test_transform_batch(self) -> None:
+        """Test transforming batches"""
+        transformer = BatchTransformer()
+
+        raw_data = {
+            "items": [
+                {
+                    "@id": "http://fdri.ceh.ac.uk/id/dataset/nrfa-batch-test_1",
+                    "title": ["NRFA Batch test_1"],
+                    "identifier": ["test_1"],
+                    "@type": [{"@id": "http://fdri.ceh.ac.uk/vocab/metadata/ObservationDatasetSeries"}],
+                    "originatingProgramme": [
+                        {"@id": "http://fdri.ceh.ac.uk/id/programme/nrfa", "label": ["NRFA Programme"]}
+                    ],
+                    "hasPart": [
+                        {
+                            "@id": "http://fdri.ceh.ac.uk/id/dataset/nrfa-batch-dataset-test_1-water-daily-flow-mean-57001",
+                            "title": ["water-daily-flow-mean for 57001 from batch test_1"],
+                            "@type": [{"@id": "http://fdri.ceh.ac.uk/vocab/metadata/ObservationDataset"}],
+                            "temporalResolution": "P1D",
+                            "temporal": {
+                                "@id": "http://fdri.ceh.ac.uk/id/dataset/nrfa-batch-test_1-water-daily-flow-mean-57001#temporal",
+                                "startDate": "2020-01-01T00:00:00",
+                                "endDate": "2025-09-30T00:00:00",
+                            },
+                            "hasAnnotation": [
+                                {
+                                    "@id": "http://fdri.ceh.ac.uk/id/dataset/nrfa-batch-dataset-test_1-water-daily-flow-mean-57001#dataset",
+                                    "hasValue": {
+                                        "@id": "http://fdri.ceh.ac.uk/id/dataset/nrfa-batch-dataset-test_1-water-daily-flow-mean-57001#dataset.value",
+                                        "value": "water-daily-flow-mean",
+                                    },
+                                },
+                                {
+                                    "@id": "http://fdri.ceh.ac.uk/id/dataset/nrfa-batch-dataset-test_1-water-daily-flow-mean-57001#filename",
+                                    "hasValue": {
+                                        "@id": "http://fdri.ceh.ac.uk/id/dataset/nrfa-batch-dataset-test_1-water-daily-flow-mean-57001#filename.value",
+                                        "value": "test_file.csv",
+                                    },
+                                },
+                            ],
+                            "processingLevel": {"@id": "http://fdri.ceh.ac.uk/ref/common/processing-level/ingested"},
+                            "measure": [{"@id": "http://fdri.ceh.ac.uk/ref/common/measure/flow-p1d-mean-m3s"}],
+                            "originatingSite": [
+                                {
+                                    "@id": "http://fdri.ceh.ac.uk/id/site/nrfa-57001",
+                                    "label": ["Taf Fechan at Taf Fechan Reservoir"],
+                                }
+                            ],
+                            "sourceColumnName": "value",
+                            "sourceBucket": "ukceh-fdri-staging-timeseries-level-0",
+                            "sourceDataset": "nrfa/batch=test_1/dataset=water-daily-flow-mean/",
+                        },
+                        {
+                            "@id": "http://fdri.ceh.ac.uk/id/dataset/nrfa-batch-dataset-test_1-water-daily-flow-mean-57002",
+                            "title": ["water-daily-flow-mean for 57002 from batch test_1"],
+                            "@type": [{"@id": "http://fdri.ceh.ac.uk/vocab/metadata/ObservationDataset"}],
+                            "temporalResolution": "P1D",
+                            "temporal": {
+                                "@id": "http://fdri.ceh.ac.uk/id/dataset/nrfa-batch-dataset-test_1-water-daily-flow-mean-57002#temporal",
+                                "startDate": "2020-01-01T00:00:00",
+                                "endDate": "2025-09-30T00:00:00",
+                            },
+                            "hasAnnotation": [
+                                {
+                                    "@id": "http://fdri.ceh.ac.uk/id/dataset/nrfa-batch-dataset-test_1-water-daily-flow-mean-57002#dataset",
+                                    "hasValue": {
+                                        "@id": "http://fdri.ceh.ac.uk/id/dataset/nrfa-batch-dataset-test_1-water-daily-flow-mean-57002#dataset.value",
+                                        "value": "water-daily-flow-mean",
+                                    },
+                                },
+                                {
+                                    "@id": "http://fdri.ceh.ac.uk/id/dataset/nrfa-batch-dataset-test_1-water-daily-flow-mean-57002#filename",
+                                    "hasValue": {
+                                        "@id": "http://fdri.ceh.ac.uk/id/dataset/nrfa-batch-dataset-test_1-water-daily-flow-mean-57002#filename.value",
+                                        "value": "test_file.csv",
+                                    },
+                                },
+                            ],
+                            "processingLevel": {"@id": "http://fdri.ceh.ac.uk/ref/common/processing-level/ingested"},
+                            "measure": [{"@id": "http://fdri.ceh.ac.uk/ref/common/measure/flow-p1d-mean-m3s"}],
+                            "originatingSite": [
+                                {
+                                    "@id": "http://fdri.ceh.ac.uk/id/site/nrfa-57002",
+                                    "label": ["Taf Fawr at Llwynon Reservoir"],
+                                }
+                            ],
+                            "sourceColumnName": "value",
+                            "sourceBucket": "ukceh-fdri-staging-timeseries-level-0",
+                            "sourceDataset": "nrfa/batch=test_1/dataset=water-daily-flow-mean/",
+                        },
+                    ],
+                }
+            ]
+        }
+
+        expected_response = [
+            {
+                "batch_id": "test_1",
+                "datasets": [
+                    BatchDataset(
+                        **{
+                            "batch_dataset_id": "http://fdri.ceh.ac.uk/id/dataset/nrfa-batch-dataset-test_1-water-daily-flow-mean-57001",
+                            "filename": "test_file.csv",
+                            "site": "57001",
+                            "variable": "flow",
+                            "aggregation": "mean",
+                            "units": "m3s",
+                            "status": "ingested",
+                            "resolution": "p1d",
+                            "measure": "flow-p1d-mean-m3s",
+                            "dataset": "water-daily-flow-mean",
+                            "start_date": datetime(2020, 1, 1, 0, 0, 0),
+                            "end_date": datetime(2025, 9, 30, 0, 0, 0),
+                            "s3_key": "nrfa/batch=test_1/dataset=water-daily-flow-mean/",
+                            "s3_bucket": "ukceh-fdri-staging-timeseries-level-0",
+                            "s3_column": "value",
+                        }
+                    ),
+                    BatchDataset(
+                        **{
+                            "batch_dataset_id": "http://fdri.ceh.ac.uk/id/dataset/nrfa-batch-dataset-test_1-water-daily-flow-mean-57002",
+                            "filename": "test_file.csv",
+                            "site": "57002",
+                            "variable": "flow",
+                            "aggregation": "mean",
+                            "units": "m3s",
+                            "status": "ingested",
+                            "resolution": "p1d",
+                            "measure": "flow-p1d-mean-m3s",
+                            "dataset": "water-daily-flow-mean",
+                            "start_date": datetime(2020, 1, 1, 0, 0, 0),
+                            "end_date": datetime(2025, 9, 30, 0, 0, 0),
+                            "s3_key": "nrfa/batch=test_1/dataset=water-daily-flow-mean/",
+                            "s3_bucket": "ukceh-fdri-staging-timeseries-level-0",
+                            "s3_column": "value",
+                        }
+                    ),
+                ],
+            }
+        ]
+
+        result = transformer.transform(raw_data)
+        assert result == expected_response


### PR DESCRIPTION
As discussed in https://github.com/NERC-CEH/dri-ingestion/pull/186 copy the batch transformer and models into this utils so they can used in the ingester (therefore bypassing calling the data api).

**Note:** There is a large refactor of the metadata functionality going on in the DAG workstream which I think should be used as the source code. Once finished this will be bought into this repo. Hence, alot of this will be removed so not been too fussed on structure and refactroing.