### PR TITLE
refactor the log structure into flat strings

### DIFF
--- a/src/driutils/json_logger.py
+++ b/src/driutils/json_logger.py
@@ -6,14 +6,6 @@ from loguru import logger
 from pydantic import BaseModel, ConfigDict
 
 
-class ErrorType(BaseModel):
-    """Error attributes"""
-
-    type: str | None = None
-    msg: str | None = None
-    stacktrace: str | None = None
-
-
 class LogEntry(BaseModel):
     """Core log entry"""
 
@@ -24,7 +16,8 @@ class LogEntry(BaseModel):
     level: str
     service_name: str
     loc: str
-    error_type: ErrorType | None = None
+    error: str | None = None
+    stacktrace: str | None = None
     thread: int
 
     # Ingestion-specific
@@ -66,14 +59,18 @@ def json_formatter(record: dict, service_name: str) -> str:
     Returns:
         A newline-terminated JSON string.
     """
-    error_type = None
+    error = None
+    stacktrace = None
     if record["exception"] is not None:
         exc_type, exc_value, exc_tb = record["exception"]
-        error_type = ErrorType(
-            type=exc_type.__name__ if exc_type else None,
-            msg=str(exc_value) if exc_value else None,
-            stacktrace="".join(traceback.format_tb(exc_tb)).strip() if exc_tb else None,
-        )
+        parts = []
+        if exc_type:
+            parts.append(exc_type.__name__)
+        if exc_value:
+            parts.append(str(exc_value))
+        error = ": ".join(parts) or None
+        if exc_tb:
+            stacktrace = "".join(traceback.format_tb(exc_tb)).strip()
 
     entry = LogEntry(
         ts=record["time"].strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
@@ -81,7 +78,8 @@ def json_formatter(record: dict, service_name: str) -> str:
         level=record["level"].name,
         service_name=service_name,
         loc=f"{record['name']}:{record['line']}",
-        error_type=error_type,
+        error=error,
+        stacktrace=stacktrace,
         thread=record["thread"].id,
         **record["extra"],
     )

--- a/tests/test_json_logger.py
+++ b/tests/test_json_logger.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 import pytest
 from pydantic import ValidationError
 
-from driutils.json_logger import ErrorType, LogEntry, json_formatter, log_extras
+from driutils.json_logger import LogEntry, json_formatter, log_extras
 
 
 def _parse(output: str) -> dict:
@@ -51,7 +51,8 @@ class TestLogEntry:
         assert entry.api_path is None
         assert entry.api_method is None
         assert entry.api_status_code is None
-        assert entry.error_type is None
+        assert entry.error is None
+        assert entry.stacktrace is None
 
     def test_extra_fields_forbidden(self) -> None:
         """Unknown fields should be rejected."""
@@ -71,18 +72,6 @@ class TestLogEntry:
         assert entry.ingestion_batch_id == "abc-123"
         assert entry.api_path == "/v1/data"
 
-
-class TestErrorType:
-    def test_all_fields_default_to_none(self) -> None:
-        error = ErrorType()
-        assert error.type is None
-        assert error.msg is None
-        assert error.stacktrace is None
-
-    def test_fields_set_correctly(self) -> None:
-        error = ErrorType(type="ValueError", msg="bad value", stacktrace="Traceback...")
-        assert error.type == "ValueError"
-        assert error.msg == "bad value"
 
 
 class TestLogExtras:
@@ -106,15 +95,16 @@ class TestJsonFormatter:
     def test_core_fields_present(self) -> None:
         record = _make_record()
         parsed = _parse(json_formatter(record, service_name="test-service").strip())
-        for field in ("ts", "msg", "level", "service_name", "loc", "error_type", "thread"):
+        for field in ("ts", "msg", "level", "service_name", "loc", "thread"):
             assert field in parsed
 
-    def test_no_exception_error_type_is_null(self) -> None:
+    def test_no_exception_error_is_null(self) -> None:
         record = _make_record()
         parsed = _parse(json_formatter(record, service_name="svc").strip())
-        assert parsed["error_type"] is None
+        assert parsed["error"] is None
+        assert parsed["stacktrace"] is None
 
-    def test_exception_populates_error_type(self) -> None:
+    def test_exception_populates_error_fields(self) -> None:
         try:
             raise ValueError("something went wrong")
         except ValueError:
@@ -123,6 +113,5 @@ class TestJsonFormatter:
 
         record = _make_record(exception=exc_info)
         parsed = _parse(json_formatter(record, service_name="svc").strip())
-        assert parsed["error_type"]["type"] == "ValueError"
-        assert parsed["error_type"]["msg"] == "something went wrong"
-        assert parsed["error_type"]["stacktrace"] is not None
+        assert parsed["error"] == "ValueError: something went wrong"
+        assert parsed["stacktrace"] is not None


### PR DESCRIPTION
Match up to common log structure for errors - two strings called `error` and `stacktrace`. This aligns with alot of common tools and should allow better integration into elastic search.

